### PR TITLE
Use `license` rather than `license-file`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Route urls to specific browsers"
 edition = "2018"
 readme = "README.md"
 repository = "https://github.com/Arrowbox/websteer"
-license-file = "LICENSE"
+license = "GPL-3.0-only"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
With `license-file`, `crates.io` shows the license as non-standard: https://crates.io/crates/websteer. Declare the license as per SPDX: https://spdx.org/licenses/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arrowbox/websteer/9)
<!-- Reviewable:end -->
